### PR TITLE
Changes "/bin/bash" to "/usr/bin/env bash" to allow usage in modern macOS

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # I usually have this kind of script in my project folder so that I don't have to manually write the configure options everytime I add new dependencies to the project
 # This is a basic one for a C project

--- a/configure.sh
+++ b/configure.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 # If the colors doesn't work under OSX, get a newer version of bash and use that one
 # You can also use zsh or disable color (WHY?!) with the -C option
 


### PR DESCRIPTION
The version of bash shipped with macOS is still out-dated (3.2.57 as of this pull request)

macOS has also added new security features preventing users from modifying the contents of /bin

This makes it impossible to symlink /bin/bash to an up to date version installed via other methods, such as homebrew  
   
Using a shebang like `#!/usr/bin/env bash` fixes this issue by letting the user's custom environment pick which bash executable to use